### PR TITLE
codebible: Keep PRs focused

### DIFF
--- a/codebible/general/keep-prs-focused.md
+++ b/codebible/general/keep-prs-focused.md
@@ -1,0 +1,9 @@
+## Keep PRs focused
+
+A Pull Request should address a single issue or feature. Avoid bundling unrelated refactors, formatting changes, or fixes that are outside the scope of the PR's objective.
+
+**Bad:**
+A PR titled "fix: login bug" that also reformats the entire `User` class and upgrades dependencies.
+
+**Good:**
+A PR titled "fix: login bug" that only touches the login logic. Separate refactors into a "refactor: ..." PR.


### PR DESCRIPTION
## Proposed rule

**Source:** https://github.com/yuv-labs/baduk/pull/28#pullrequestreview-3835391996

**Original comment:**
> There are too many changes that are not related to the issue you are trying to resolve.

---
- **Merge** to accept this rule into the codebible.
- **Close** to reject.