### PR TITLE
codebible: Comments should explain "why", not "what"

### DIFF
--- a/codebible/general/explain-why-not-what-in-comments.md
+++ b/codebible/general/explain-why-not-what-in-comments.md
@@ -1,0 +1,24 @@
+## Comments should explain "why", not "what"
+
+Comments that merely restate what the code does are redundant and can drift out of sync with the implementation.
+Instead, use comments to explain **why** a non-obvious approach was taken, or to document constraints and side effects.
+
+**Bad:**
+
+```typescript
+// increment i by 1
+i++;
+
+// set the user active
+user.active = true;
+```
+
+**Good:**
+
+```typescript
+// increment to skip the header row
+i++;
+
+// activate immediately to prevent race condition in subsequent login check
+user.active = true;
+```


### PR DESCRIPTION
## Proposed rule

**Source:** https://github.com/yuv-labs/baduk/pull/33#discussion_r2853617158

**Original comment:**
> This comment is kind of redundant because the code around the comment clearly shows what they do by themselves. please avoid the comment of what the code does.(unless it's unavoidable). Leave a comment, only you need to explain why the code has to be written like that. (not what but why)

---
- **Merge** to accept this rule into the codebible.
- **Close** to reject.